### PR TITLE
Apply login-style buttons to homepage

### DIFF
--- a/frontend/src/components/Navbar/Navbar.css
+++ b/frontend/src/components/Navbar/Navbar.css
@@ -50,14 +50,7 @@
 
 .auth-buttons a,
 .auth-buttons button.logout-button {
-  background-color: #C7A86B;    /* Fortino gold soft */
-  color: #0D1B12;               /* Fortino dark green */
-  padding: 0.5rem 1rem;
-  border-radius: 0.375rem;
-  text-decoration: none;
-  font-weight: 500;
-  border: none;
-  cursor: pointer;
+  @apply auth-button;
 }
 
 .auth-buttons a:hover,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -83,6 +83,23 @@ p {
   filter: brightness(0.9);
 }
 
+/* Button style used for Login/Register and Home page actions */
+.auth-button {
+  display: inline-block;
+  background-color: #C7A86B; /* Fortino gold soft */
+  color: #0D1B12;           /* Fortino dark green */
+  padding: 0.5rem 1rem;
+  border-radius: 0.375rem;
+  font-weight: 500;
+  text-decoration: none;
+  border: none;
+  cursor: pointer;
+}
+
+.auth-button:hover {
+  opacity: 0.9;
+}
+
 .btn-danger {
   background-color: var(--color-danger-dark);
   color: var(--color-light);

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,7 +1,6 @@
 // src/pages/Home.jsx
 import React from 'react';
 import { Link } from 'react-router-dom';
-import Button from '../components/UI/Button';
 
 /**
  * Home
@@ -32,10 +31,7 @@ const Home = () => {
           <p className="text-fortino-softWhite">
             Browse live odds and place bets on your favorite sports.
           </p>
-          <Link
-            to="/sports"
-            className="inline-block bg-fortino-goldSoft text-fortino-darkGreen px-4 py-2 rounded-md font-medium hover:opacity-90 mt-4"
-          >
+          <Link to="/sports" className="auth-button mt-4">
             Bet Now
           </Link>
         </div>
@@ -48,10 +44,7 @@ const Home = () => {
           <p className="text-fortino-softWhite">
             Enjoy slots, roulette, poker and more from your browser.
           </p>
-          <Link
-            to="/casino"
-            className="inline-block bg-fortino-goldSoft text-fortino-darkGreen px-4 py-2 rounded-md font-medium hover:opacity-90 mt-4"
-          >
+          <Link to="/casino" className="auth-button mt-4">
             Play Now
           </Link>
         </div>
@@ -67,10 +60,8 @@ const Home = () => {
           <p className="text-fortino-softWhite">
             Play with real dealers in real-time via live stream.
           </p>
-          <Link to="/casino">
-            <Button variant="primary" className="mt-4">
-              Learn More
-            </Button>
+          <Link to="/casino" className="auth-button mt-4">
+            Learn More
           </Link>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add global `.auth-button` style
- reuse `.auth-button` in navbar and homepage links
- update homepage to apply the new button style

## Testing
- `npm run build` in `frontend`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68448707ed28832fa7cc528bd436f9b1