### PR TITLE
Update Home page actions and texts

### DIFF
--- a/frontend/src/Casino/GameCard.jsx
+++ b/frontend/src/Casino/GameCard.jsx
@@ -1,6 +1,7 @@
 // src/Casino/GameCard.jsx
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { useAuth } from '../hooks/useAuth';
 
 /**
  * GameCard
@@ -16,6 +17,7 @@ import { Link } from 'react-router-dom';
  *     }
  */
 const GameCard = ({ game }) => {
+  const { user } = useAuth();
   return (
     <div className="bg-fortino-darkGreen rounded-lg overflow-hidden shadow-md hover:shadow-lg transition-shadow duration-200">
       {/* Game thumbnail or icon */}
@@ -45,7 +47,7 @@ const GameCard = ({ game }) => {
 
         {/* Link to GameDetail page */}
         <Link
-          to={`/casino/${game.id}`}
+          to={user ? `/casino/${game.id}` : '/login'}
           className="inline-block bg-fortino-goldSoft text-black font-medium px-4 py-2 rounded-md hover:bg-fortino-goldSoft/90 transition duration-150"
         >
           Play Now

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -47,7 +47,7 @@
   },
   "casino": {
     "welcome": "Welcome to Fortino Casino",
-    "discoverGames": "Discover a variety of thrilling casino games: slots, roulette, poker, and more. Play live with real dealers or enjoy instant-play games from anywhere.",
+    "discoverGames": "Discover a variety of thrilling casino games: slots, roulette, poker and more. Enjoy instant-play games from anywhere.",
     "exploreGames": "Explore Games",
     "casinoGames": "Casino Games",
     "playNow": "Play Now",

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,13 +1,15 @@
 // src/pages/Home.jsx
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { useAuth } from '../hooks/useAuth';
 
 /**
  * Home
  *
- * Landing page with quick access to Sports Betting, Casino, and Live Casino.
- */
+ * Landing page with quick access to Sports Betting and Casino.
+*/
 const Home = () => {
+  const { user } = useAuth();
   return (
     <div className="max-w-5xl mx-auto mt-12 space-y-12">
       {/* Hero Section */}
@@ -31,7 +33,7 @@ const Home = () => {
           <p className="text-fortino-softWhite">
             Browse live odds and place bets on your favorite sports.
           </p>
-          <Link to="/sports" className="auth-button mt-4">
+          <Link to={user ? '/sports' : '/login'} className="auth-button mt-4">
             Bet Now
           </Link>
         </div>
@@ -44,24 +46,8 @@ const Home = () => {
           <p className="text-fortino-softWhite">
             Enjoy slots, roulette, poker and more from your browser.
           </p>
-          <Link to="/casino" className="auth-button mt-4">
+          <Link to={user ? '/casino' : '/login'} className="auth-button mt-4">
             Play Now
-          </Link>
-        </div>
-
-        {/* Live Casino */}
-        <div className="p-6 bg-fortino-darkGreen rounded-lg hover:bg-fortino-darkGreen/80 transition relative">
-          <span className="absolute top-4 right-4 bg-fortino-oliveGreen text-black text-xs font-semibold px-2 py-1 rounded">
-            LIVE
-          </span>
-          <h2 className="text-2xl font-semibold text-fortino-softWhite mb-2">
-            Live Casino
-          </h2>
-          <p className="text-fortino-softWhite">
-            Play with real dealers in real-time via live stream.
-          </p>
-          <Link to="/casino" className="auth-button mt-4">
-            Learn More
           </Link>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- remove Live Casino section from home
- show 'Bet Now' and 'Play Now' links only when logged in
- redirect to login when not logged in
- gate casino game links based on login status
- tweak casino translation text

## Testing
- `npm install` inside `frontend`
- `npm run build` inside `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68448fa6f1f0832fb0ef7b0a6c2d81b7