### PR TITLE
Fix broken Fortino logo in Navbar

### DIFF
--- a/frontend/src/components/Navbar/Navbar.jsx
+++ b/frontend/src/components/Navbar/Navbar.jsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import LanguageSwitcher from '../../Common/LanguageSwitcher';
 import { useAuth } from '../../hooks/useAuth';
 import './Navbar.css';
+import logo from '../../assets/images/logo.png';
 
 const Navbar = () => {
   const { user, logoutUser } = useAuth();
@@ -12,8 +13,7 @@ const Navbar = () => {
     <nav className="navbar">
       <div className="navbar-left">
         <Link to="/">
-          {/* Replace the src with the correct path to your logo file */}
-          <img src="/assets/images/logo.png" alt="Fortino Logo" className="logo" />
+          <img src={logo} alt="Fortino Logo" className="logo" />
         </Link>
 
         <ul className="nav-links">


### PR DESCRIPTION
## Summary
- import the logo image in `Navbar.jsx`
- reference the imported image instead of a broken path

## Testing
- `npm run build` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_6844913e1454832f89ac5edb90cbc776