### PR TITLE
Update navbar layout

### DIFF
--- a/frontend/src/components/Navbar/Navbar.css
+++ b/frontend/src/components/Navbar/Navbar.css
@@ -3,7 +3,7 @@
 .navbar {
   background-color: #0D1B12; /* Fortino dark green */
   color: #F5F5F5;            /* Fortino soft white */
-  padding: 1rem 2rem;
+  padding: 0.75rem 2rem;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -16,7 +16,7 @@
 }
 
 .logo {
-  height: 80px;
+  height: 50px;
 }
 
 .nav-links {
@@ -25,6 +25,8 @@
   list-style: none;
   margin: 0;
   padding: 0;
+  flex-grow: 1;
+  justify-content: center;
 }
 
 .nav-links li a {

--- a/frontend/src/components/Navbar/Navbar.jsx
+++ b/frontend/src/components/Navbar/Navbar.jsx
@@ -15,22 +15,19 @@ const Navbar = () => {
         <Link to="/">
           <img src={logo} alt="Fortino Logo" className="logo" />
         </Link>
-
-        <ul className="nav-links">
-          <li>
-            <Link to="/">Home</Link>
-          </li>
-          <li>
-            <Link to="/sports">Sports</Link>
-          </li>
-          <li>
-            <Link to="/casino">Casino</Link>
-          </li>
-          <li>
-            <Link to="/promotions">Promotions</Link>
-          </li>
-        </ul>
       </div>
+
+      <ul className="nav-links">
+        <li>
+          <Link to="/sports">Sports</Link>
+        </li>
+        <li>
+          <Link to="/casino">Casino</Link>
+        </li>
+        <li>
+          <Link to="/promotions">Promotions</Link>
+        </li>
+      </ul>
 
       <div className="navbar-right">
         <LanguageSwitcher />


### PR DESCRIPTION
## Summary
- center navbar links between logo and auth buttons
- shrink navbar size
- link homepage through logo and remove explicit Home link

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_6844a4753dfc832fb2bef1ccb3ed6483