### PR TITLE
Add game preview component and seed games

### DIFF
--- a/backend/src/data/initialCasinoGames.js
+++ b/backend/src/data/initialCasinoGames.js
@@ -1,0 +1,17 @@
+module.exports = [
+  {
+    title: 'Slots & Sorcery',
+    thumbnailUrl: 'https://placehold.co/300x200?text=Slots+%26+Sorcery',
+    playUrl: 'https://milkbaggames.itch.io/slots-and-sorcery'
+  },
+  {
+    title: 'Free Money Slot',
+    thumbnailUrl: 'https://placehold.co/300x200?text=Free+Money',
+    playUrl: 'https://noiki.itch.io/free-money'
+  },
+  {
+    title: 'HTML5 Slot Machine',
+    thumbnailUrl: 'https://placehold.co/300x200?text=HTML5+Slot+Machine',
+    playUrl: 'https://johakr.github.io/html5-slot-machine/'
+  }
+];

--- a/backend/src/models/CasinoGame.js
+++ b/backend/src/models/CasinoGame.js
@@ -19,6 +19,10 @@ const casinoGameSchema = new Schema({
     type: String,
     required: true,
   },
+  playUrl: {
+    type: String,
+    required: true,
+  },
   description: {
     type: String,
   },

--- a/backend/src/services/casinoService.js
+++ b/backend/src/services/casinoService.js
@@ -1,11 +1,15 @@
 const CasinoGame = require('../models/CasinoGame');
+const initialGames = require('../data/initialCasinoGames');
 
 /**
  * Retrieve all casino games available.
  * Returns an array of CasinoGame documents.
  */
 async function getAllGames() {
-  const games = await CasinoGame.find({});
+  let games = await CasinoGame.find({});
+  if (games.length === 0) {
+    games = await CasinoGame.insertMany(initialGames);
+  }
   return games;
 }
 
@@ -15,7 +19,11 @@ async function getAllGames() {
  */
 async function getGameById(gameId) {
   // Assuming gameId corresponds to MongoDB _id
-  const game = await CasinoGame.findById(gameId);
+  let game = await CasinoGame.findById(gameId);
+  if (!game) {
+    await getAllGames();
+    game = await CasinoGame.findById(gameId);
+  }
   return game;
 }
 

--- a/frontend/src/Casino/GameCard.jsx
+++ b/frontend/src/Casino/GameCard.jsx
@@ -1,6 +1,5 @@
 // src/Casino/GameCard.jsx
 import React from 'react';
-import { Link } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
 
 /**
@@ -18,13 +17,18 @@ import { useAuth } from '../hooks/useAuth';
  */
 const GameCard = ({ game }) => {
   const { user } = useAuth();
+  const name = game.name || game.title;
+  const imageUrl = game.imageUrl || game.thumbnailUrl;
+  const playLink = user ? game.playUrl : '/login';
+  const anchorProps = user ? { target: '_blank', rel: 'noopener noreferrer' } : {};
+
   return (
     <div className="bg-fortino-darkGreen rounded-lg overflow-hidden shadow-md hover:shadow-lg transition-shadow duration-200">
       {/* Game thumbnail or icon */}
       <div className="h-40 w-full overflow-hidden">
         <img
-          src={game.imageUrl}
-          alt={game.name}
+          src={imageUrl}
+          alt={name}
           className="object-cover w-full h-full"
           onError={(e) => {
             // Fallback to a placeholder image if the URL is invalid
@@ -37,7 +41,7 @@ const GameCard = ({ game }) => {
       {/* Game name and category */}
       <div className="p-4">
         <h3 className="text-lg font-semibold text-fortino-softWhite mb-1">
-          {game.name}
+          {name}
         </h3>
         {game.category && (
           <p className="text-sm text-fortino-goldSoft mb-3">
@@ -45,13 +49,14 @@ const GameCard = ({ game }) => {
           </p>
         )}
 
-        {/* Link to GameDetail page */}
-        <Link
-          to={user ? `/casino/${game.id}` : '/login'}
+        {/* Link directly to the game */}
+        <a
+          href={playLink}
+          {...anchorProps}
           className="inline-block bg-fortino-goldSoft text-black font-medium px-4 py-2 rounded-md hover:bg-fortino-goldSoft/90 transition duration-150"
         >
           Play Now
-        </Link>
+        </a>
       </div>
     </div>
   );

--- a/frontend/src/Casino/GameDetail.jsx
+++ b/frontend/src/Casino/GameDetail.jsx
@@ -47,17 +47,20 @@ const GameDetail = () => {
     return <div>Game not found.</div>;
   }
 
+  const name = game.name || game.title;
+  const imageUrl = game.imageUrl || game.thumbnailUrl;
+
   return (
     <div className="max-w-4xl mx-auto p-6 bg-fortino-darkGreen rounded-lg text-fortino-softWhite">
       {/* Game Title */}
-      <h1 className="text-4xl font-bold mb-4">{game.name}</h1>
+      <h1 className="text-4xl font-bold mb-4">{name}</h1>
 
       <div className="flex flex-col md:flex-row gap-6">
         {/* Left: Game Image */}
         <div className="md:w-1/2 w-full h-64 md:h-auto overflow-hidden rounded-lg shadow-lg">
           <img
-            src={game.imageUrl}
-            alt={game.name}
+            src={imageUrl}
+            alt={name}
             className="object-cover w-full h-full"
             onError={(e) => {
               e.currentTarget.src =

--- a/frontend/src/Casino/HomeGamesPreview.jsx
+++ b/frontend/src/Casino/HomeGamesPreview.jsx
@@ -1,0 +1,34 @@
+import React, { useEffect, useState } from 'react';
+import casinoService from '../services/casinoService';
+import GameCard from './GameCard';
+
+const HomeGamesPreview = () => {
+  const [games, setGames] = useState([]);
+
+  useEffect(() => {
+    const fetchGames = async () => {
+      try {
+        const data = await casinoService.getGames();
+        setGames(data.slice(0, 3));
+      } catch (err) {
+        console.error(err);
+      }
+    };
+
+    fetchGames();
+  }, []);
+
+  if (games.length === 0) return null;
+
+  return (
+    <div className="flex gap-4 overflow-x-auto py-4">
+      {games.map((game) => (
+        <div key={game._id || game.id} className="w-64 flex-shrink-0">
+          <GameCard game={game} />
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default HomeGamesPreview;

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
+import HomeGamesPreview from '../Casino/HomeGamesPreview';
 
 /**
  * Home
@@ -37,6 +38,7 @@ const Home = () => {
           <p className="text-fortino-softWhite">
             Enjoy slots, roulette, poker and more from your browser.
           </p>
+          <HomeGamesPreview />
           <Link to={user ? '/casino' : '/login'} className="auth-button mt-4">
             Play Now
           </Link>


### PR DESCRIPTION
## Summary
- seed casino games with play URL, thumbnails, and titles
- expose seeded games via casino service
- allow `GameCard` to open the game directly
- preview a few games on the Home page

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6844aece46d4832fb55789c9d7a1f043