### PR TITLE
Update footer spacing and language dropdown style

### DIFF
--- a/frontend/src/Common/LanguageSwitcher.jsx
+++ b/frontend/src/Common/LanguageSwitcher.jsx
@@ -21,7 +21,7 @@ const LanguageSwitcher = () => {
       <select
         value={lang}
         onChange={handleChange}
-        className="bg-fortino-darkGreen text-fortino-softWhite px-2 py-1 rounded-md focus:outline-none focus:ring-2 focus:ring-fortino-goldSoft"
+        className="bg-fortino-darkGreen text-fortino-softWhite border border-fortino-goldSoft px-2 py-1 rounded-md focus:outline-none focus:ring-2 focus:ring-fortino-goldSoft"
       >
         <option value="en">English</option>
         <option value="es">Español</option>

--- a/frontend/src/components/Footer/Footer.css
+++ b/frontend/src/components/Footer/Footer.css
@@ -8,6 +8,7 @@
   justify-content: space-between;
   align-items: center;
   flex-wrap: wrap;
+  margin-top: 1rem; /* space above footer */
 }
 
 .footer-left p {


### PR DESCRIPTION
## Summary
- add margin above footer for breathing room
- style language selector with a gold border that matches site colors

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6844b132b3d4832f8a0d993a74d07743