### PR TITLE
Show casino game thumbnails on home

### DIFF
--- a/frontend/src/Casino/GameThumbnail.jsx
+++ b/frontend/src/Casino/GameThumbnail.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { useAuth } from '../hooks/useAuth';
+
+/**
+ * GameThumbnail
+ *
+ * Simple image-only representation of a casino game. If the user is logged in,
+ * clicking the image will open the game's play URL in a new tab. Otherwise the
+ * link redirects to the login page.
+ */
+const GameThumbnail = ({ game }) => {
+  const { user } = useAuth();
+  const name = game.name || game.title;
+  const imageUrl = game.imageUrl || game.thumbnailUrl;
+  const link = user ? game.playUrl : '/login';
+  const anchorProps = user ? { target: '_blank', rel: 'noopener noreferrer' } : {};
+
+  const imgElement = (
+    <img
+      src={imageUrl}
+      alt={name}
+      className="object-cover w-full h-full rounded-lg"
+      onError={(e) => {
+        e.currentTarget.src = 'https://via.placeholder.com/300x200?text=No+Image';
+      }}
+    />
+  );
+
+  return (
+    <div className="w-48 h-32 overflow-hidden">
+      {user ? (
+        <a href={link} {...anchorProps}>{imgElement}</a>
+      ) : (
+        <a href={link}>{imgElement}</a>
+      )}
+    </div>
+  );
+};
+
+export default GameThumbnail;

--- a/frontend/src/Casino/HomeGamesPreview.jsx
+++ b/frontend/src/Casino/HomeGamesPreview.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import casinoService from '../services/casinoService';
-import GameCard from './GameCard';
+import GameThumbnail from './GameThumbnail';
 
 const HomeGamesPreview = () => {
   const [games, setGames] = useState([]);
@@ -23,9 +23,7 @@ const HomeGamesPreview = () => {
   return (
     <div className="flex gap-4 overflow-x-auto py-4">
       {games.map((game) => (
-        <div key={game._id || game.id} className="w-64 flex-shrink-0">
-          <GameCard game={game} />
-        </div>
+        <GameThumbnail key={game._id || game.id} game={game} />
       ))}
     </div>
   );


### PR DESCRIPTION
## Summary
- add `GameThumbnail` component to display game thumbnails with login-aware links
- show `GameThumbnail` in `HomeGamesPreview`

## Testing
- `npm test --silent` *(fails: no tests defined)*
- `cd frontend && npm install --silent`
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_6844b230d66c832f9978b91e516bab98