### PR TITLE
Improve footer language selector

### DIFF
--- a/frontend/src/Common/LanguageSwitcher.css
+++ b/frontend/src/Common/LanguageSwitcher.css
@@ -1,0 +1,11 @@
+.language-switcher {
+  @apply relative inline-block;
+}
+
+.language-select {
+  @apply appearance-none bg-fortino-darkGreen text-fortino-softWhite border border-fortino-goldSoft py-2 pl-3 pr-8 rounded-md focus:outline-none focus:ring-2 focus:ring-fortino-goldSoft;
+}
+
+.select-arrow {
+  @apply pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-fortino-goldSoft w-4 h-4;
+}

--- a/frontend/src/Common/LanguageSwitcher.jsx
+++ b/frontend/src/Common/LanguageSwitcher.jsx
@@ -1,6 +1,7 @@
 // src/Common/LanguageSwitcher.jsx
 import React from 'react';
 import { useI18n } from '../hooks/useI18n';
+import './LanguageSwitcher.css';
 
 /**
  * LanguageSwitcher
@@ -17,16 +18,29 @@ const LanguageSwitcher = () => {
   };
 
   return (
-    <div className="inline-block">
+    <div className="language-switcher">
       <select
         value={lang}
         onChange={handleChange}
-        className="bg-fortino-darkGreen text-fortino-softWhite border border-fortino-goldSoft px-2 py-1 rounded-md focus:outline-none focus:ring-2 focus:ring-fortino-goldSoft"
+        className="language-select"
       >
         <option value="en">English</option>
         <option value="es">Español</option>
         <option value="pt">Português</option>
       </select>
+      <svg
+        className="select-arrow"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 20 20"
+        fill="currentColor"
+        aria-hidden="true"
+      >
+        <path
+          fillRule="evenodd"
+          d="M5.23 7.21a.75.75 0 011.06.02L10 10.94l3.71-3.71a.75.75 0 111.06 1.06l-4.24 4.24a.75.75 0 01-1.06 0L5.21 8.29a.75.75 0 01.02-1.08z"
+          clipRule="evenodd"
+        />
+      </svg>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- polish the language switcher styles
- add custom CSS for the dropdown and arrow

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6844b38909e4832f9e632e92b75f0425