### PR TITLE
Add Roulette Royale

### DIFF
--- a/frontend/src/Casino/RouletteRoyaleEmbed.jsx
+++ b/frontend/src/Casino/RouletteRoyaleEmbed.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+const RouletteRoyaleEmbed = () => (
+  <div className="w-full aspect-video rounded overflow-hidden">
+    <iframe
+      src="https://showcase.codethislab.com/games/roulette_royale/"
+      title="Roulette Royale"
+      width="100%"
+      height="100%"
+      allowFullScreen
+      className="w-full h-full border-0"
+    />
+  </div>
+);
+
+export default RouletteRoyaleEmbed;

--- a/frontend/src/pages/CasinoPage.jsx
+++ b/frontend/src/pages/CasinoPage.jsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import CasinoBanner from '../Casino/CasinoBanner';
 import CasinoList from '../Casino/CasinoList';
+import RouletteRoyaleEmbed from '../Casino/RouletteRoyaleEmbed';
 
 /**
  * CasinoPage
@@ -13,6 +14,7 @@ const CasinoPage = () => {
   return (
     <div className="space-y-8 mt-8">
       <CasinoBanner />
+      <RouletteRoyaleEmbed />
       <CasinoList />
     </div>
   );

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
 import HomeGamesPreview from '../Casino/HomeGamesPreview';
+import rouletteImage from '../assets/images/roulette-royale.jpg';
 
 /**
  * Home
@@ -39,6 +40,11 @@ const Home = () => {
             Enjoy slots, roulette, poker and more from your browser.
           </p>
           <HomeGamesPreview />
+          <img
+            src={rouletteImage}
+            alt="Roulette Royale"
+            className="w-full my-4 rounded"
+          />
           <Link to={user ? '/casino' : '/login'} className="auth-button mt-4">
             Play Now
           </Link>


### PR DESCRIPTION
## Summary
- show roulette royale image on home screen
- embed Roulette Royale game on casino page

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844ba01dbbc832f8bd496beaca19f4d