### PR TITLE
Adjust footer order and bottom spacing

### DIFF
--- a/frontend/src/components/Footer/Footer.jsx
+++ b/frontend/src/components/Footer/Footer.jsx
@@ -7,14 +7,14 @@ import LanguageSwitcher from '../../Common/LanguageSwitcher';
 const Footer = () => {
   return (
     <footer className="footer">
+      <div className="footer-center">
+        <p>© 2025 Fortino Casino.</p>
+      </div>
+
       <div className="footer-links">
         <Link to="/terms">Terms of Service</Link>
         <Link to="/privacy">Privacy Policy</Link>
         <Link to="/contact">Contact</Link>
-      </div>
-
-      <div className="footer-center">
-        <p>&copy; {new Date().getFullYear()} Fortino Casino. All rights reserved.</p>
       </div>
 
       <div className="footer-right">

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -12,7 +12,7 @@ import HomeGamesPreview from '../Casino/HomeGamesPreview';
 const Home = () => {
   const { user } = useAuth();
   return (
-    <div className="max-w-5xl mx-auto mt-12 space-y-12">
+    <div className="max-w-5xl mx-auto mt-12 space-y-12 pb-20">
 
 
       {/* Feature Cards */}


### PR DESCRIPTION
## Summary
- swap footer text position with links and shorten text
- increase padding at bottom of home page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6844bab12868832f91022dfe57dc5f7a