### PR TITLE
Remove casino tag text and size preview

### DIFF
--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -36,14 +36,11 @@ const Home = () => {
           <h2 className="text-2xl font-semibold text-fortino-softWhite mb-2">
             Online Casino
           </h2>
-          <p className="text-fortino-softWhite">
-            Enjoy slots, roulette, poker and more from your browser.
-          </p>
           <HomeGamesPreview />
           <img
             src={rouletteImage}
             alt="Roulette Royale"
-            className="w-full my-4 rounded"
+            className="w-48 my-4 rounded"
           />
           <Link to={user ? '/casino' : '/login'} className="auth-button mt-4">
             Play Now


### PR DESCRIPTION
## Summary
- remove casino text
- make casino preview image small

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6844bcb36b40832f850cb65dcf682fe4