### PR TITLE
Add mini casino embeds and thumbnails

### DIFF
--- a/frontend/src/Casino/MiniGameEmbed.jsx
+++ b/frontend/src/Casino/MiniGameEmbed.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+const MiniGameEmbed = ({ src, title }) => (
+  <div className="w-[200px] h-[200px] rounded overflow-hidden shadow-lg">
+    <iframe
+      src={src}
+      title={title}
+      width="100%"
+      height="100%"
+      allowFullScreen
+      className="w-full h-full border-0"
+    />
+  </div>
+);
+
+export default MiniGameEmbed;

--- a/frontend/src/pages/CasinoPage.jsx
+++ b/frontend/src/pages/CasinoPage.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import CasinoBanner from '../Casino/CasinoBanner';
 import CasinoList from '../Casino/CasinoList';
 import RouletteRoyaleEmbed from '../Casino/RouletteRoyaleEmbed';
+import MiniGameEmbed from '../Casino/MiniGameEmbed';
 
 /**
  * CasinoPage
@@ -15,6 +16,24 @@ const CasinoPage = () => {
     <div className="space-y-8 mt-8">
       <CasinoBanner />
       <RouletteRoyaleEmbed />
+      <div className="flex flex-wrap justify-center gap-4">
+        <MiniGameEmbed
+          src="https://html-classic.itch.zone/html/6772510/SlotsSorceryWeb/index.html"
+          title="Slots and Sorcery"
+        />
+        <MiniGameEmbed
+          src="https://html-classic.itch.zone/html/7128217/index.html"
+          title="Plot Luck"
+        />
+        <MiniGameEmbed
+          src="https://html-classic.itch.zone/html/12847895/index.html"
+          title="Slot Splitter"
+        />
+        <MiniGameEmbed
+          src="https://html-classic.itch.zone/html/5731992/index.html"
+          title="The Casino"
+        />
+      </div>
       <CasinoList />
     </div>
   );

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -4,6 +4,8 @@ import { Link } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
 import HomeGamesPreview from '../Casino/HomeGamesPreview';
 import rouletteImage from '../assets/images/roulette-royale.jpg';
+import plotLuckImage from '../assets/images/plot-luck.png';
+import slotsSorceryImage from '../assets/images/slots-sorcery.png';
 
 /**
  * Home
@@ -37,11 +39,11 @@ const Home = () => {
             Online Casino
           </h2>
           <HomeGamesPreview />
-          <img
-            src={rouletteImage}
-            alt="Roulette Royale"
-            className="w-48 my-4 rounded"
-          />
+          <div className="flex gap-2 my-4">
+            <img src={rouletteImage} alt="Roulette Royale" className="w-[200px] rounded" />
+            <img src={plotLuckImage} alt="Plot Luck" className="w-[200px] rounded" />
+            <img src={slotsSorceryImage} alt="Slots and Sorcery" className="w-[200px] rounded" />
+          </div>
           <Link to={user ? '/casino' : '/login'} className="auth-button mt-4">
             Play Now
           </Link>


### PR DESCRIPTION
## Summary
- embed extra casino games with a new `MiniGameEmbed` component
- display the new mini games on the casino page
- show thumbnail previews for Plot Luck and Slots & Sorcery on the home page

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844bf010624832fa4f4a0a0fe6b6228