### PR TITLE
Fix footer alignment

### DIFF
--- a/frontend/src/components/Footer/Footer.css
+++ b/frontend/src/components/Footer/Footer.css
@@ -10,12 +10,12 @@
   flex-wrap: wrap;
 }
 
-.footer-center {
+.footer-left {
   flex: 1;
-  text-align: center;
+  text-align: left;
 }
 
-.footer-center p {
+.footer-left p {
   margin: 0;
   font-size: 0.9rem;
 }

--- a/frontend/src/components/Footer/Footer.jsx
+++ b/frontend/src/components/Footer/Footer.jsx
@@ -7,7 +7,7 @@ import LanguageSwitcher from '../../Common/LanguageSwitcher';
 const Footer = () => {
   return (
     <footer className="footer">
-      <div className="footer-center">
+      <div className="footer-left">
         <p>© 2025 Fortino Casino.</p>
       </div>
 


### PR DESCRIPTION
## Summary
- move copyright text to new `.footer-left` section
- update CSS to left align the text
- keep footer links centered

## Testing
- `npm install` *(in `/workspace/KRMBet`)*
- `npm install` *(in `frontend`)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6844bf8bb060832f8e2b6e45067ac770